### PR TITLE
remove sourceRootPrefixIndex

### DIFF
--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -125,7 +125,7 @@ func TestStringableSlice(t *testing.T) {
 func TestCustomLogFormatter(t *testing.T) {
 	b := new(bytes.Buffer)
 	serviceLogger := GetLogger(Node("node1"), Service("public-api")).
-		WithOutput(NewFormattingOutput(b, NewHumanReadableFormatter())).WithSourcePrefix("scribe/")
+		WithOutput(NewFormattingOutput(b, NewHumanReadableFormatter()))
 	serviceLogger.Info("Service initialized",
 		Int("some-int-value", 12),
 		Int("block-height", 9999),
@@ -235,9 +235,7 @@ func TestJsonFormatterWithCustomTimestampColumn(t *testing.T) {
 }
 
 func Test_getCaller(t *testing.T) {
-	l := &basicLogger{
-		sourceRootPrefixIndex: getSourceRootPrefixIndex("scribe/"),
-	}
+	l := &basicLogger{}
 
 	function, source := l.getCaller(2)
 


### PR DESCRIPTION
`sourceRootPrefixIndex` field assumes all calls are from a single package. but during testing on `orbs-network-go` we sometimes find golang packages as the file name. and this results in either corrupt filenames or index out of bounds exceptions.

Perhaps there is a different bug which now causes golang built in packages to be quoted in scribe calls. this puzzles me a little.

but in any case, since we now use scribe across several modules and repos this feature seems a little simplistic. so i removed it.

@netoneko does this look good to you?
  