### PR TITLE
HttpWriter - adding timeout, support 2XX HTTP responses

### DIFF
--- a/log/bulk_output.go
+++ b/log/bulk_output.go
@@ -79,26 +79,34 @@ func NewBulkOutput(writer io.Writer, formatter LogFormatter, bulkSize int) Outpu
 }
 
 type httpWriter struct {
-	url string
+	url     string
+	timeout time.Duration
 }
 
 func (w *httpWriter) Write(p []byte) (n int, err error) {
 	reader := bytes.NewReader(p)
 	size := reader.Len()
-	resp, err := http.Post(w.url, "application/json", reader)
+	client := &http.Client{
+		Timeout: w.timeout,
+	}
+	resp, err := client.Post(w.url, "application/json", reader)
 
 	if err != nil {
 		return 0, errors.Errorf("Failed to send logs: %s", err)
 	}
 
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return 0, errors.Errorf("Failed to send logs: %d, %s", resp.StatusCode, err)
 	}
 
 	return size, err
 }
 
-func NewHttpWriter(url string) io.Writer {
-	return &httpWriter{url}
+func NewHttpWriter(url string) *httpWriter {
+	return &httpWriter{url, time.Second * 60}
+}
+
+func NewHttpWriterWithTimeout(url string, timeout time.Duration) *httpWriter {
+	return &httpWriter{url, timeout}
 }

--- a/log/bulk_output.go
+++ b/log/bulk_output.go
@@ -79,17 +79,14 @@ func NewBulkOutput(writer io.Writer, formatter LogFormatter, bulkSize int) Outpu
 }
 
 type httpWriter struct {
-	url     string
-	timeout time.Duration
+	url        string
+	httpClient *http.Client
 }
 
 func (w *httpWriter) Write(p []byte) (n int, err error) {
 	reader := bytes.NewReader(p)
 	size := reader.Len()
-	client := &http.Client{
-		Timeout: w.timeout,
-	}
-	resp, err := client.Post(w.url, "application/json", reader)
+	resp, err := w.httpClient.Post(w.url, "application/json", reader)
 
 	if err != nil {
 		return 0, errors.Errorf("Failed to send logs: %s", err)
@@ -104,9 +101,9 @@ func (w *httpWriter) Write(p []byte) (n int, err error) {
 }
 
 func NewHttpWriter(url string) *httpWriter {
-	return &httpWriter{url, time.Second * 60}
+	return NewHttpWriterWithTimeout(url, time.Second*60)
 }
 
 func NewHttpWriterWithTimeout(url string, timeout time.Duration) *httpWriter {
-	return &httpWriter{url, timeout}
+	return &httpWriter{url, &http.Client{Timeout: timeout}}
 }


### PR DESCRIPTION
fixes #11 
- Treating HTTP 2XX as success, instead of only HTTP 200
- Adding a default request timeout of 60 seconds for HttpWriter